### PR TITLE
Update cloud-init and fix a few bugs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ module "controller_build" {
   source = "./modules/controller_build"
   // please do not use special characters such as `\/"[]:|<>+=;,?*@&~!#$%^()_{}'` in the controller_name
   controller_name                           = var.controller_name
+  controller_version                        = var.controller_version
   location                                  = var.location
   controller_vnet_cidr                      = var.controlplane_vnet_cidr
   controller_subnet_cidr                    = var.controlplane_subnet_cidr
@@ -25,7 +26,8 @@ module "controller_build" {
   vnet_name                                 = var.vnet_name
   subnet_name                               = var.subnet_name
   subnet_id                                 = var.subnet_id
-  environment                               = var.environment #For internal use only
+  environment                               = var.environment         #For internal use only
+  registry_auth_token                       = var.registry_auth_token #For internal use only
 
   depends_on = [
     module.azure_marketplace_agreement
@@ -36,7 +38,7 @@ module "controller_init" {
   count = var.module_config.controller_initialization ? 1 : 0
 
   source  = "terraform-aviatrix-modules/controller-init/aviatrix"
-  version = "v1.0.3"
+  version = "v1.0.4"
 
   controller_public_ip      = module.controller_build[0].controller_public_ip_address
   controller_private_ip     = module.controller_build[0].controller_private_ip_address

--- a/modules/controller_build/cloud-init-prod.yml
+++ b/modules/controller_build/cloud-init-prod.yml
@@ -1,3 +1,0 @@
-#cloud-config
-avx-controller:
-  avx-controller-version: latest

--- a/modules/controller_build/cloud-init-staging.yml
+++ b/modules/controller_build/cloud-init-staging.yml
@@ -1,4 +1,0 @@
-#cloud-config
-avx-controller:
-  environment: staging
-  avx-controller-version: latest

--- a/modules/controller_build/cloud-init.tftpl
+++ b/modules/controller_build/cloud-init.tftpl
@@ -1,0 +1,7 @@
+#cloud-config
+avx-controller:
+  avx-controller-version: ${controller_version}
+  environment: ${environment}
+  extra-bootstrap-args:
+    image-registry: registry-release.${environment}.sre.aviatrix.com
+    image-registry-auth: ${registry_auth_token}

--- a/modules/controller_build/variables.tf
+++ b/modules/controller_build/variables.tf
@@ -9,6 +9,12 @@ variable "controller_name" {
   description = "Customized Name for Aviatrix Controller"
 }
 
+variable "controller_version" {
+  type        = string
+  description = "Aviatrix Controller version"
+  default     = "latest"
+}
+
 variable "controller_vnet_cidr" {
   type        = string
   description = "CIDR for controller VNET."
@@ -86,3 +92,12 @@ variable "environment" {
     error_message = "The environment must be either 'prod' or 'staging'."
   }
 }
+
+# terraform-docs-ignore
+variable "registry_auth_token" {
+  description = "The token used to authenticate to the controller artifact registry. For internal use only."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -168,3 +168,12 @@ variable "environment" {
     error_message = "The environment must be either 'prod' or 'staging'."
   }
 }
+
+# terraform-docs-ignore
+variable "registry_auth_token" {
+  description = "The token used to authenticate to the controller artifact registry. For internal use only."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+


### PR DESCRIPTION
Use a single cloud-init template for environments with parametrization.

Fix a dependency issue that causes `terraform destroy` to sometimes fail.

Update controller-init module version.