### PR TITLE
Add support to resource tags and use CoPilot security group group rule seperate resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ module "controller_build" {
   environment                               = var.environment         #For internal use only
   registry_auth_token                       = var.registry_auth_token #For internal use only
   create_storage_account                    = var.create_storage_account
-
+  tags                                      = var.tags
   depends_on = [
     module.azure_marketplace_agreement
   ]
@@ -79,6 +79,7 @@ module "copilot_build" {
   image_version                  = var.copilot_image_version
   location                       = var.location
   environment                    = var.environment #For internal use only
+  tags                           = var.tags
 
   allowed_cidrs = {
     "tcp_cidrs_https" = {

--- a/modules/controller_build/main.tf
+++ b/modules/controller_build/main.tf
@@ -9,6 +9,10 @@ resource "azurerm_resource_group" "controller_rg" {
   count    = var.use_existing_resource_group ? 0 : 1
   location = var.location
   name     = "${var.controller_name}-rg"
+  tags     = var.tags
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 # 2. Create the Virtual Network and Subnet
@@ -19,6 +23,10 @@ resource "azurerm_virtual_network" "controller_vnet" {
   location            = var.location
   name                = "${var.controller_name}-vnet"
   resource_group_name = var.use_existing_resource_group ? var.resource_group_name : azurerm_resource_group.controller_rg[0].name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [tags]
+  }
 }
 
 //  Create the Subnet
@@ -40,6 +48,10 @@ resource "azurerm_public_ip" "controller_public_ip" {
   name                = "${var.controller_name}-public-ip"
   sku                 = "Standard"
   resource_group_name = var.use_existing_resource_group ? var.resource_group_name : azurerm_resource_group.controller_rg[0].name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [tags]
+  }
 
   depends_on = [azurerm_resource_group.controller_rg]
 }
@@ -55,6 +67,10 @@ resource "azurerm_network_security_group" "controller_nsg" {
   location            = var.location
   name                = "${var.controller_name}-security-group"
   resource_group_name = var.use_existing_resource_group ? var.resource_group_name : azurerm_resource_group.controller_rg[0].name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [tags]
+  }
 
   depends_on = [azurerm_resource_group.controller_rg]
 }
@@ -80,6 +96,11 @@ resource "azurerm_network_interface" "controller_nic" {
   location            = var.location
   name                = "${var.controller_name}-network-interface-card"
   resource_group_name = var.use_existing_resource_group ? var.resource_group_name : azurerm_resource_group.controller_rg[0].name
+  tags                = var.tags
+  lifecycle {
+    ignore_changes = [tags]
+  }
+
   ip_configuration {
     name                          = "${var.controller_name}-nic"
     private_ip_address_allocation = "Dynamic"
@@ -114,6 +135,8 @@ resource "azurerm_linux_virtual_machine" "controller_vm" {
   network_interface_ids           = [azurerm_network_interface.controller_nic.id]
   resource_group_name             = var.use_existing_resource_group ? var.resource_group_name : azurerm_resource_group.controller_rg[0].name
   size                            = var.controller_virtual_machine_size
+  tags                            = var.tags
+
   custom_data = base64encode(templatefile("${path.module}/cloud-init.tftpl", {
     controller_version  = var.controller_version
     environment         = var.environment
@@ -144,7 +167,7 @@ resource "azurerm_linux_virtual_machine" "controller_vm" {
   depends_on = [azurerm_network_interface.controller_nic]
 
   lifecycle {
-    ignore_changes = [source_image_reference, plan]
+    ignore_changes = [source_image_reference, plan, tags]
   }
 }
 

--- a/modules/controller_build/variables.tf
+++ b/modules/controller_build/variables.tf
@@ -143,6 +143,12 @@ resource "random_string" "storage_account_name_padding" {
   special = false
 }
 
+variable "tags" {
+  description = "Provide tags for resources created by the module"
+  type = map(string)
+  default = {}
+}
+
 locals {
   default_storage_account_name = substr(format("%s%s", lower(replace(var.controller_name, "-", "")), random_string.storage_account_name_padding.result), 0, 24) #Storage accounts require global unique names.
   storage_account_name         = var.storage_account_name == "" ? local.default_storage_account_name : var.storage_account_name

--- a/modules/copilot_build/variables.tf
+++ b/modules/copilot_build/variables.tf
@@ -181,6 +181,12 @@ variable "environment" {
   }
 }
 
+variable "tags" {
+  description = "Provide tags for resources created by the module"
+  type = map(string)
+  default = {}
+}
+
 locals {
   ssh_key             = var.add_ssh_key ? (var.use_existing_ssh_key == false ? tls_private_key.key_pair_material[0].public_key_openssh : (var.ssh_public_key_file_path != "" ? file(var.ssh_public_key_file_path) : var.ssh_public_key_file_content)) : ""
   controller_ip       = var.private_mode ? var.controller_private_ip : var.controller_public_ip

--- a/variables.tf
+++ b/variables.tf
@@ -265,3 +265,10 @@ variable "cloud_type" {
     error_message = "The cloud_type must be either 'commercial' or 'china'."
   }
 }
+
+
+variable "tags" {
+  description = "Provide tags for resources created by the module"
+  type = map(string)
+  default = {}
+}


### PR DESCRIPTION
1. Added Support for Tags on the resources created by the module.

2. Updated CoPilot Security Group management, previouly NSG rules are included in azurerm_network_security_group.copilot_nsg, when CoPilot perform NSG management it created a drift between TF state and NSG rules. This has been seperated to azurerm_network_security_rule.copilot_nsg_rules resource.

When running apply following errors would occure for the three NSG rules created by azurerm_network_security_group.copilot_nsg: tcp_cidrs_https, tcp_cidrs, udp_cidrs

Error: A resource with the ID "/subscriptions/<subscription_id>/resourceGroups/<rg_name>/providers/Microsoft.Network/networkSecurityGroups/<controller_name>-security-group/securityRules/tcp_cidrs_https" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_network_security_rule" for more information.
 
  with module.control_plane.module.copilot_build[0].azurerm_network_security_rule.copilot_nsg_rules["tcp_cidrs_https"],
  on ../../terraform-aviatrix-azure-controlplane/modules/copilot_build/main.tf line 76, in resource "azurerm_network_security_rule" "copilot_nsg_rules":
  76: resource "azurerm_network_security_rule" "copilot_nsg_rules" {

You just need to add three import blocks for each error to import these three resources into terraform state:
import {
  to = module.control_plane.module.copilot_build[0].azurerm_network_security_rule.copilot_nsg_rules["tcp_cidrs"]
  id = "/subscriptions/<subscription_id>/resourceGroups/<rg_name>/providers/Microsoft.Network/networkSecurityGroups/<controller_name>-copilot-security-group/securityRules/tcp_cidrs"
}