### PR TITLE
Fixed an issue with Azure NSG

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -4,5 +4,5 @@ locals {
   copilot_public_ip        = var.module_config.copilot_deployment ? [module.copilot_build[0].public_ip] : []
   copilot_private_ip       = var.module_config.copilot_deployment ? [module.copilot_build[0].private_ip] : []
   copilot_ips              = concat(local.copilot_private_ip, local.copilot_public_ip)
-  controller_allowed_cidrs = concat(var.incoming_ssl_cidrs, local.copilot_ips)
+  controller_allowed_cidrs = contains(var.incoming_ssl_cidrs, "0.0.0.0/0") ? ["0.0.0.0/0"] : concat(var.incoming_ssl_cidrs, local.copilot_ips)
 }


### PR DESCRIPTION
When giving the incoming_ssl_cidrs as 0.0.0.0/0, the terraform fails with below error. 

Error: creating/updating Security Rule (Subscription: "5095fbebxxxxxxxxxx"
│ Resource Group Name: "ctrl-rg"
│ Network Security Group Name: "ctrl-security-group"
│ Security Rule Name: "https"): performing CreateOrUpdate: unexpected status 400 with error: OverlappingSubnetsNotPermittedInSecurityRule: Security rule parameter SourceAddressPrefix for rule with Id /subscriptions/5095fbebxxxxxxxxxxxx/resourceGroups/ctrl71-rg/providers/Microsoft.Network/networkSecurityGroups/ctrl71-security-group/securityRules/https contains overlapping subnets [0.0.0.0/0, x.x.x.x/32], which is not permitted.

This is due to the variable controller_allowed_cidrs is concatenating the var.incoming_ssl_cidrs with the local.copilot_ips where the local.copilot_ips has both CoPilot private and public IP. So when we add 0.0.0.0/0 to the variable incoming_ssl_cidrs which covers the all IP's and Azure doesn't not permit this. In order to fix this just added a "if-else" condition to the controller_allowed_cidrs variable. This will just add 0.0.0.0/0 to the Controller NSG. 


```
controller_allowed_cidrs = contains(var.incoming_ssl_cidrs, "0.0.0.0/0") ? ["0.0.0.0/0"] : concat(var.incoming_ssl_cidrs, local.copilot_ips)
``` 